### PR TITLE
Feature/get my play list service

### DIFF
--- a/Client-iOS/Client-iOS.xcodeproj/project.pbxproj
+++ b/Client-iOS/Client-iOS.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		5CA13CFB27479A5D007FAFFF /* AlbumTrackListForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CA13CFA27479A5D007FAFFF /* AlbumTrackListForm.swift */; };
 		5CA5FA1D27438D2900452724 /* MyPlayListHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5CA5FA1B27438D2900452724 /* MyPlayListHeaderView.xib */; };
 		5CA5FA1E27438D2900452724 /* MyPlayListHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CA5FA1C27438D2900452724 /* MyPlayListHeaderView.swift */; };
+		5CF2D80527585B8000ED0F74 /* GetMyMusicService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF2D80427585B8000ED0F74 /* GetMyMusicService.swift */; };
 		BD01C867274637D2003619F9 /* BaseVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD01C866274637D2003619F9 /* BaseVC.swift */; };
 		BD01C86927463CA1003619F9 /* PreparingVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD01C86827463CA1003619F9 /* PreparingVC.swift */; };
 		BD041987273EDAE700347610 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD041986273EDAE700347610 /* AppDelegate.swift */; };
@@ -87,6 +88,7 @@
 		5CA13CFA27479A5D007FAFFF /* AlbumTrackListForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumTrackListForm.swift; sourceTree = "<group>"; };
 		5CA5FA1B27438D2900452724 /* MyPlayListHeaderView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MyPlayListHeaderView.xib; sourceTree = "<group>"; };
 		5CA5FA1C27438D2900452724 /* MyPlayListHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MyPlayListHeaderView.swift; sourceTree = "<group>"; };
+		5CF2D80427585B8000ED0F74 /* GetMyMusicService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetMyMusicService.swift; sourceTree = "<group>"; };
 		5E9FF60D647B06C0E21B9D0B /* Pods-Client-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Client-iOS.debug.xcconfig"; path = "Target Support Files/Pods-Client-iOS/Pods-Client-iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		BD01C866274637D2003619F9 /* BaseVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseVC.swift; sourceTree = "<group>"; };
 		BD01C86827463CA1003619F9 /* PreparingVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreparingVC.swift; sourceTree = "<group>"; };
@@ -169,6 +171,14 @@
 				5C065D87275267480080F72E /* NetworkResult.swift */,
 			);
 			path = Network;
+			sourceTree = "<group>";
+		};
+		5CF2D80327585B6600ED0F74 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				5CF2D80427585B8000ED0F74 /* GetMyMusicService.swift */,
+			);
+			path = Services;
 			sourceTree = "<group>";
 		};
 		BBE43E5C5E0B2323A9DBADA6 /* Pods */ = {
@@ -262,6 +272,7 @@
 		BD10D124273F96D400B395B4 /* MyMusic */ = {
 			isa = PBXGroup;
 			children = (
+				5CF2D80327585B6600ED0F74 /* Services */,
 				BD10D125273F96F800B395B4 /* MyMusicVC.swift */,
 				BD10D13E273F99EE00B395B4 /* MyMusicVC.storyboard */,
 				BD10D131273F97F800B395B4 /* Views */,
@@ -504,6 +515,7 @@
 				2B45DB3127422A9C00C90091 /* QuickMenuCVC.swift in Sources */,
 				5C065D88275267480080F72E /* NetworkResult.swift in Sources */,
 				2B45DB342742305300C90091 /* TestVC.swift in Sources */,
+				5CF2D80527585B8000ED0F74 /* GetMyMusicService.swift in Sources */,
 				5C9F0F51274379C200A73DF2 /* MyPlayListForm.swift in Sources */,
 				BD10D12A273F975A00B395B4 /* Color.swift in Sources */,
 				BD10D12C273F976700B395B4 /* Typography.swift in Sources */,

--- a/Client-iOS/Client-iOS/Scenes/MyMusic/MyMusicVC+DataSource.swift
+++ b/Client-iOS/Client-iOS/Scenes/MyMusic/MyMusicVC+DataSource.swift
@@ -9,8 +9,6 @@ import UIKit
 
 final class MyMusicVCDataSource: NSObject, UICollectionViewDataSource {
     // 데이터 가변적으로 보여주기 위한 변수
-    var dataCount = 5
-    var countList = [0, 0, 1, 0]
     var dataCount = 0
     var countList = [0, 0, 0, 0]
     var myPlayList = [MyPlayListData]()
@@ -35,8 +33,8 @@ final class MyMusicVCDataSource: NSObject, UICollectionViewDataSource {
             return cell
         case .myPlayList:
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MyPlayListCVC.ID, for: indexPath) as! MyPlayListCVC
-//            let data = dummyMyPlayListData()
-//            cell.setData(data: data[indexPath.row])
+            cell.tag = indexPath.row
+            cell.setData(data: myPlayList[indexPath.row])
             return cell
         }
     }

--- a/Client-iOS/Client-iOS/Scenes/MyMusic/MyMusicVC+DataSource.swift
+++ b/Client-iOS/Client-iOS/Scenes/MyMusic/MyMusicVC+DataSource.swift
@@ -5,6 +5,7 @@
 //  Created by taehy.k on 2021/11/18.
 //
 
+import Foundation
 import UIKit
 
 final class MyMusicVCDataSource: NSObject, UICollectionViewDataSource {
@@ -65,9 +66,9 @@ final class MyMusicVCDataSource: NSObject, UICollectionViewDataSource {
                 view.action = { [weak self] (state: ToggleState) in
                     switch state {
                     case .fold:
-                        self?.dataCount = 10
+                        self?.dataCount = self?.myPlayList.count ?? 0
                     case .unfold:
-                        self?.dataCount = 5
+                        self?.dataCount = (self?.myPlayList.count ?? 0) / 2
                     }
                     collectionView.reloadData()
                 }

--- a/Client-iOS/Client-iOS/Scenes/MyMusic/MyMusicVC+DataSource.swift
+++ b/Client-iOS/Client-iOS/Scenes/MyMusic/MyMusicVC+DataSource.swift
@@ -11,6 +11,10 @@ final class MyMusicVCDataSource: NSObject, UICollectionViewDataSource {
     // 데이터 가변적으로 보여주기 위한 변수
     var dataCount = 5
     var countList = [0, 0, 1, 0]
+    var dataCount = 0
+    var countList = [0, 0, 0, 0]
+    var myPlayList = [MyPlayListData]()
+    
     func numberOfSections(in collectionView: UICollectionView) -> Int {
         2
     }

--- a/Client-iOS/Client-iOS/Scenes/MyMusic/MyMusicVC+DataSource.swift
+++ b/Client-iOS/Client-iOS/Scenes/MyMusic/MyMusicVC+DataSource.swift
@@ -10,7 +10,7 @@ import UIKit
 final class MyMusicVCDataSource: NSObject, UICollectionViewDataSource {
     // 데이터 가변적으로 보여주기 위한 변수
     var dataCount = 5
-    
+    var countList = [0, 0, 1, 0]
     func numberOfSections(in collectionView: UICollectionView) -> Int {
         2
     }
@@ -26,11 +26,13 @@ final class MyMusicVCDataSource: NSObject, UICollectionViewDataSource {
         switch MyMusicSection.allCases[indexPath.section] {
         case .quickMenu:
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "QuickMenuCV", for: indexPath) as! QuickMenuCV
+            cell.countList = countList
+            cell.quickMenuCollectionView.reloadData()
             return cell
         case .myPlayList:
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MyPlayListCVC.ID, for: indexPath) as! MyPlayListCVC
-            let data = dummyMyPlayListData()
-            cell.setData(data: data[indexPath.row])
+//            let data = dummyMyPlayListData()
+//            cell.setData(data: data[indexPath.row])
             return cell
         }
     }

--- a/Client-iOS/Client-iOS/Scenes/MyMusic/MyMusicVC.swift
+++ b/Client-iOS/Client-iOS/Scenes/MyMusic/MyMusicVC.swift
@@ -5,6 +5,7 @@
 //  Created by taehy.k on 2021/11/13.
 //
 
+import Foundation
 import UIKit
 
 final class MyMusicVC: BaseVC {

--- a/Client-iOS/Client-iOS/Scenes/MyMusic/MyMusicVC.swift
+++ b/Client-iOS/Client-iOS/Scenes/MyMusic/MyMusicVC.swift
@@ -17,7 +17,7 @@ final class MyMusicVC: BaseVC {
     // MARK: - Properties
     
     private let dataSource = MyMusicVCDataSource()
-    let getMyMusicService = GetMyMusicService.shared
+    private let getMyMusicService = GetMyMusicService.shared
     
     // MARK: - Life cycles
     
@@ -70,19 +70,19 @@ final class MyMusicVC: BaseVC {
     // MARK: - Custom Method
     
     private func fetchMyMusicData() {
-        getMyMusicService.requestGetMyMusic(id: "1") { responseData in
+        getMyMusicService.requestGetMyMusic(id: "1") { [weak self] responseData in
             switch responseData {
             case .success(let myMusicResponse):
-                guard let response = myMusicResponse as? GetMyMusicResponseData else { return }
-                self.dataSource.countList = [
-                    response.data?.likeCount ?? 0,
-                    response.data?.saveCount ?? 0,
-                    response.data?.recentPlayedCount ?? 0,
-                    response.data?.mostPlayedCount ?? 0
+                guard let response = myMusicResponse as? GetMyMusicResultData else { return }
+                self?.dataSource.countList = [
+                    response.likeCount,
+                    response.saveCount,
+                    response.recentPlayedCount,
+                    response.mostPlayedCount
                 ]
-                self.dataSource.myPlayList = response.data?.likes ?? [MyPlayListData]()
-                self.dataSource.dataCount = (response.data?.likes.count ?? 0) / 2
-                self.collectionView.reloadData()
+                self?.dataSource.myPlayList = response.likes
+                self?.dataSource.dataCount = response.likes.count / 2
+                self?.collectionView.reloadData()
 
             default:
                 print("데이터 불러오기 실패")

--- a/Client-iOS/Client-iOS/Scenes/MyMusic/MyMusicVC.swift
+++ b/Client-iOS/Client-iOS/Scenes/MyMusic/MyMusicVC.swift
@@ -16,8 +16,13 @@ final class MyMusicVC: BaseVC {
     // MARK: - Properties
     
     private let dataSource = MyMusicVCDataSource()
+    let getMyMusicService = GetMyMusicService.shared
     
     // MARK: - Life cycles
+    
+    override func viewWillAppear(_ animated: Bool) {
+        fetchMyMusicData()
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -59,6 +64,19 @@ final class MyMusicVC: BaseVC {
             forSupplementaryViewOfKind: UICollectionView.elementKindSectionFooter,
             withReuseIdentifier: "MyPlayListFooterView"
         )
+    }
+    
+    // MARK: fetchMyMusicData()
+    private func fetchMyMusicData() {
+        getMyMusicService.requestGetMyMusic(id: "1") { responseData in
+            switch responseData {
+            case .success(let myMusicResponse):
+                guard let response = myMusicResponse as? GetMyMusicResponseData else { return }
+                print("response data: \(response)")
+            default:
+                print("데이터 불러오기 실패")
+            }
+        }
     }
 }
 

--- a/Client-iOS/Client-iOS/Scenes/MyMusic/MyMusicVC.swift
+++ b/Client-iOS/Client-iOS/Scenes/MyMusic/MyMusicVC.swift
@@ -79,7 +79,10 @@ final class MyMusicVC: BaseVC {
                     response.data?.recentPlayedCount ?? 0,
                     response.data?.mostPlayedCount ?? 0
                 ]
+                self.dataSource.myPlayList = response.data?.likes ?? [MyPlayListData]()
+                self.dataSource.dataCount = (response.data?.likes.count ?? 0) / 2
                 self.collectionView.reloadData()
+
             default:
                 print("데이터 불러오기 실패")
             }

--- a/Client-iOS/Client-iOS/Scenes/MyMusic/MyMusicVC.swift
+++ b/Client-iOS/Client-iOS/Scenes/MyMusic/MyMusicVC.swift
@@ -66,13 +66,20 @@ final class MyMusicVC: BaseVC {
         )
     }
     
-    // MARK: fetchMyMusicData()
+    // MARK: - Custom Method
+    
     private func fetchMyMusicData() {
         getMyMusicService.requestGetMyMusic(id: "1") { responseData in
             switch responseData {
             case .success(let myMusicResponse):
                 guard let response = myMusicResponse as? GetMyMusicResponseData else { return }
-                print("response data: \(response)")
+                self.dataSource.countList = [
+                    response.data?.likeCount ?? 0,
+                    response.data?.saveCount ?? 0,
+                    response.data?.recentPlayedCount ?? 0,
+                    response.data?.mostPlayedCount ?? 0
+                ]
+                self.collectionView.reloadData()
             default:
                 print("데이터 불러오기 실패")
             }

--- a/Client-iOS/Client-iOS/Scenes/MyMusic/MyPlayListForm.swift
+++ b/Client-iOS/Client-iOS/Scenes/MyMusic/MyPlayListForm.swift
@@ -5,19 +5,34 @@
 //  Created by 1v1 on 2021/11/16.
 //
 
+import Foundation
 import UIKit
-// 여기에 데이터 형태랑 더미데이터 넣어 뒀는데... TableView 그리면서 데이터 갖다 쓰면 되고... 뷰컨에 올릴 때에는 dummyMyPlayListData()만 뷰컨 내부에 옮기시면 될 듯합니다...
 
-struct MyPlayListForm {
-    var albumImage: UIImage
-    var albumTitle: String
-    var albumCount: Int
+struct GetMyMusicResponseData: Codable {
+    let status: Int
+    let success: Bool
+    let message: String
+    let data: GetMyMusicResultData?
 }
 
-func dummyMyPlayListData() -> [MyPlayListForm] {
-    var data = [MyPlayListForm]()
-    for x in 1..<11 {
-        data.append(MyPlayListForm(albumImage: UIImage(named: "cover_\(x)")!, albumTitle: "2021.11.09", albumCount: 5))
-    }
-    return data
+struct GetMyMusicResultData: Codable {
+    let likeCount: Int
+    let saveCount: Int
+    let recentPlayedCount: Int
+    let mostPlayedCount: Int
+    let likes: [MyPlayListData]
 }
+
+struct MyPlayListData: Codable {
+    let id: Int
+    let title: String
+    let description: String
+}
+
+//func dummyMyPlayListData() -> [MyPlayListForm] {
+//    var data = [MyPlayListForm]()
+//    for x in 1..<11 {
+//        data.append(MyPlayListForm(albumImage: UIImage(named: "cover_\(x)")!, albumTitle: "2021.11.09", albumCount: 5))
+//    }
+//    return data
+//}

--- a/Client-iOS/Client-iOS/Scenes/MyMusic/MyPlayListForm.swift
+++ b/Client-iOS/Client-iOS/Scenes/MyMusic/MyPlayListForm.swift
@@ -28,11 +28,3 @@ struct MyPlayListData: Codable {
     let title: String
     let description: String
 }
-
-//func dummyMyPlayListData() -> [MyPlayListForm] {
-//    var data = [MyPlayListForm]()
-//    for x in 1..<11 {
-//        data.append(MyPlayListForm(albumImage: UIImage(named: "cover_\(x)")!, albumTitle: "2021.11.09", albumCount: 5))
-//    }
-//    return data
-//}

--- a/Client-iOS/Client-iOS/Scenes/MyMusic/MyPlayListForm.swift
+++ b/Client-iOS/Client-iOS/Scenes/MyMusic/MyPlayListForm.swift
@@ -5,9 +5,6 @@
 //  Created by 1v1 on 2021/11/16.
 //
 
-import Foundation
-import UIKit
-
 struct GetMyMusicResponseData: Codable {
     let status: Int
     let success: Bool

--- a/Client-iOS/Client-iOS/Scenes/MyMusic/Services/GetMyMusicService.swift
+++ b/Client-iOS/Client-iOS/Scenes/MyMusic/Services/GetMyMusicService.swift
@@ -18,9 +18,9 @@ struct GetMyMusicService {
 //            "password": password
 //        ]
         
-        let request = AF.request(url, method: .post, parameters: body, encoding: JSONEncoding.default, headers: header)
+        let request = AF.request(url, method: .get, encoding: JSONEncoding.default)
         
-        dataRequest.responseData { dataResponse in
+        request.responseData { dataResponse in
             switch dataResponse.result {
             case .success:
                 guard let statusCode = dataResponse.response?.statusCode else { return }
@@ -37,8 +37,8 @@ struct GetMyMusicService {
     private func judgeSignInStatus(by statusCode: Int, _ data: Data) -> NetworkResult<Any> {
         switch statusCode {
         case 200: return isVaildSignInData(data: data)
-        case 400: return isVaildSignInData(data: data) // .pathErr
-        case 500: return isVaildSignInData(data: data) // .serverErr
+        case 400: return isVaildSignInData(data: data)
+        case 500: return isVaildSignInData(data: data)
         default: return .networkFail
         }
     }

--- a/Client-iOS/Client-iOS/Scenes/MyMusic/Services/GetMyMusicService.swift
+++ b/Client-iOS/Client-iOS/Scenes/MyMusic/Services/GetMyMusicService.swift
@@ -12,12 +12,6 @@ struct GetMyMusicService {
     
     func requestGetMyMusic(id: String, completion: @escaping (NetworkResult<Any>) -> (Void)) {
         let url = APIConstants.getMyPlayListURL + id
-        //        let header: HTTPHeaders = ["Content-Type": "application/json"]
-        //        let body: Parameters = [
-        //            "email": email,
-        //            "password": password
-        //        ]
-        
         let request = AF.request(url, method: .get, encoding: JSONEncoding.default)
         
         request.responseData { dataResponse in

--- a/Client-iOS/Client-iOS/Scenes/MyMusic/Services/GetMyMusicService.swift
+++ b/Client-iOS/Client-iOS/Scenes/MyMusic/Services/GetMyMusicService.swift
@@ -1,0 +1,51 @@
+//
+//  MyMusicService.swift
+//  Client-iOS
+//
+//  Created by 1v1 on 2021/12/02.
+//
+
+import Alamofire
+
+struct GetMyMusicService {
+    static let shared = GetMyMusicService()
+
+    func requestSignIn(id: String, completion: @escaping (NetworkResult<Any>) -> (Void)) {
+        let url = APIConstants.getMyPlayListURL + id
+//        let header: HTTPHeaders = ["Content-Type": "application/json"]
+//        let body: Parameters = [
+//            "email": email,
+//            "password": password
+//        ]
+        
+        let request = AF.request(url, method: .post, parameters: body, encoding: JSONEncoding.default, headers: header)
+        
+        dataRequest.responseData { dataResponse in
+            switch dataResponse.result {
+            case .success:
+                guard let statusCode = dataResponse.response?.statusCode else { return }
+                guard let value = dataResponse.value else { return }
+                let networkResult = self.judgeSignInStatus(by: statusCode, value)
+                completion(networkResult)
+            case .failure(let error):
+                print(error)
+                completion(.networkFail)
+            }
+        }
+    }
+    
+    private func judgeSignInStatus(by statusCode: Int, _ data: Data) -> NetworkResult<Any> {
+        switch statusCode {
+        case 200: return isVaildSignInData(data: data)
+        case 400: return isVaildSignInData(data: data) // .pathErr
+        case 500: return isVaildSignInData(data: data) // .serverErr
+        default: return .networkFail
+        }
+    }
+    
+    private func isVaildSignInData(data: Data) -> NetworkResult<Any> {
+        let decoder = JSONDecoder()
+        guard let decodedData = try? decoder.decode(SignInResponseData.self, from: data) else { return .pathErr }
+        return .success(decodedData)
+    }
+}

--- a/Client-iOS/Client-iOS/Scenes/MyMusic/Services/GetMyMusicService.swift
+++ b/Client-iOS/Client-iOS/Scenes/MyMusic/Services/GetMyMusicService.swift
@@ -9,14 +9,14 @@ import Alamofire
 
 struct GetMyMusicService {
     static let shared = GetMyMusicService()
-
-    func requestSignIn(id: String, completion: @escaping (NetworkResult<Any>) -> (Void)) {
+    
+    func requestGetMyMusic(id: String, completion: @escaping (NetworkResult<Any>) -> (Void)) {
         let url = APIConstants.getMyPlayListURL + id
-//        let header: HTTPHeaders = ["Content-Type": "application/json"]
-//        let body: Parameters = [
-//            "email": email,
-//            "password": password
-//        ]
+        //        let header: HTTPHeaders = ["Content-Type": "application/json"]
+        //        let body: Parameters = [
+        //            "email": email,
+        //            "password": password
+        //        ]
         
         let request = AF.request(url, method: .get, encoding: JSONEncoding.default)
         
@@ -25,7 +25,7 @@ struct GetMyMusicService {
             case .success:
                 guard let statusCode = dataResponse.response?.statusCode else { return }
                 guard let value = dataResponse.value else { return }
-                let networkResult = self.judgeSignInStatus(by: statusCode, value)
+                let networkResult = self.judgeMyMusicStatus(by: statusCode, value)
                 completion(networkResult)
             case .failure(let error):
                 print(error)
@@ -34,18 +34,18 @@ struct GetMyMusicService {
         }
     }
     
-    private func judgeSignInStatus(by statusCode: Int, _ data: Data) -> NetworkResult<Any> {
+    private func judgeMyMusicStatus(by statusCode: Int, _ data: Data) -> NetworkResult<Any> {
         switch statusCode {
-        case 200: return isVaildSignInData(data: data)
-        case 400: return isVaildSignInData(data: data)
-        case 500: return isVaildSignInData(data: data)
+        case 200: return isVaildMyMusicData(data: data)
+        case 400: return .pathErr
+        case 500: return .serverErr
         default: return .networkFail
         }
     }
     
-    private func isVaildSignInData(data: Data) -> NetworkResult<Any> {
+    private func isVaildMyMusicData(data: Data) -> NetworkResult<Any> {
         let decoder = JSONDecoder()
-        guard let decodedData = try? decoder.decode(SignInResponseData.self, from: data) else { return .pathErr }
+        guard let decodedData = try? decoder.decode(GetMyMusicResponseData.self, from: data) else { return .pathErr }
         return .success(decodedData)
     }
 }

--- a/Client-iOS/Client-iOS/Scenes/MyMusic/Services/GetMyMusicService.swift
+++ b/Client-iOS/Client-iOS/Scenes/MyMusic/Services/GetMyMusicService.swift
@@ -40,6 +40,6 @@ struct GetMyMusicService {
     private func isVaildMyMusicData(data: Data) -> NetworkResult<Any> {
         let decoder = JSONDecoder()
         guard let decodedData = try? decoder.decode(GetMyMusicResponseData.self, from: data) else { return .pathErr }
-        return .success(decodedData)
+        return .success(decodedData.data ?? GetMyMusicResultData(likeCount: 0, saveCount: 0, recentPlayedCount: 0, mostPlayedCount: 0, likes: []))
     }
 }

--- a/Client-iOS/Client-iOS/Scenes/MyMusic/Views/MyPlayListCVC.swift
+++ b/Client-iOS/Client-iOS/Scenes/MyMusic/Views/MyPlayListCVC.swift
@@ -18,9 +18,9 @@ class MyPlayListCVC: UICollectionViewCell {
     @IBOutlet weak var albumTitleLabel: UILabel!
     @IBOutlet weak var albumCountLabel: UILabel!
     
-    func setData(data: MyPlayListForm) {
-        albumImageView.image = data.albumImage
-        albumTitleLabel.text = data.albumTitle
-        albumCountLabel.text = "\(data.albumCount)곡"
-    }
+//    func setData(data: MyPlayListForm) {
+//        albumImageView.image = data.albumImage
+//        albumTitleLabel.text = data.albumTitle
+//        albumCountLabel.text = "\(data.albumCount)곡"
+//    }
 }

--- a/Client-iOS/Client-iOS/Scenes/MyMusic/Views/MyPlayListCVC.swift
+++ b/Client-iOS/Client-iOS/Scenes/MyMusic/Views/MyPlayListCVC.swift
@@ -18,9 +18,9 @@ class MyPlayListCVC: UICollectionViewCell {
     @IBOutlet weak var albumTitleLabel: UILabel!
     @IBOutlet weak var albumCountLabel: UILabel!
     
-//    func setData(data: MyPlayListForm) {
-//        albumImageView.image = data.albumImage
-//        albumTitleLabel.text = data.albumTitle
-//        albumCountLabel.text = "\(data.albumCount)곡"
-//    }
+    func setData(data: MyPlayListData) {
+        albumImageView.image = UIImage(named: "cover_\(self.tag + 1)")!
+        albumTitleLabel.text = data.title
+        albumCountLabel.text = data.description
+    }
 }

--- a/Client-iOS/Client-iOS/Scenes/MyMusic/Views/QuickMenuCV.swift
+++ b/Client-iOS/Client-iOS/Scenes/MyMusic/Views/QuickMenuCV.swift
@@ -12,7 +12,7 @@ class QuickMenuCV: UICollectionViewCell {
     // MARK: - Dummy Data
     private var categoryList = ["내가 좋아한", "내가 보관한", "최근 재생한", "많이 재생한"]
     private var iconList = ["icn_heart", "icn_keep", "icn_time", "icn_play"]
-    private var countList = [55, 2, 127, 87]
+    var countList = [0, 0, 0, 0]
     private var coverList = ["quickMenuCover_1", "quickMenuCover_2", "quickMenuCover_3", "quickMenuCover_4"]
     
     @IBOutlet weak var quickMenuCollectionView: UICollectionView!


### PR DESCRIPTION
## PR 요약
* getMyPlayList(내 음악 가져오기)를 요청을 실행한 후 받은 데이터를 보여 주기(Closed #21)

## 작업 내용
* Scenes/MyMusic/Services 폴더 및 GetMyMusicService.swift 파일 생성
* 네트워크 서비스 코드 작성
* 기존 DataForm(MyPlayListForm)을 api 요구사항에 맞게 수정
* 데이터를 view에 보여 주기
* myPlayList fold/unfold 효과를 위해` fold:  데이터 개수 / 2, unfold: 데이터 전체 개수`로 변경

## 코멘트
<img width="303" alt="스크린샷 2021-12-02 오후 1 51 40" src="https://user-images.githubusercontent.com/43312096/144359902-147b9533-8f4c-4415-a594-6416822b4571.png">
* 이 부분의 `전체 211` 부분 숫자가 의미하는 바가 명확하지 않고(개수가 안 맞음,,) 서버에서도 이 부분에 대한 값을 안 넘겨 주기 때문에 우선 디자인에 있는 대로 211로 그대로 뒀습니다,,


<img width="300" alt="스크린샷 2021-12-02 오후 1 53 28" src="https://user-images.githubusercontent.com/43312096/144360083-06181e8c-1941-43cf-ba03-277e71c210ac.png">
* '플레이리스트1입니다.' 부분이 디자인 상에서는 수록곡 개수였는데, api가 들어올 때 description(String)으로 들어와서 일단 들어온 그대로 넣어 두었습니다,,.~!
