### PR TITLE
Fix: 내 음악 뷰 이미지 크래시 이슈 (#30)

### DIFF
--- a/Client-iOS/Client-iOS/Scenes/MyMusic/Views/MyPlayListCVC.swift
+++ b/Client-iOS/Client-iOS/Scenes/MyMusic/Views/MyPlayListCVC.swift
@@ -19,7 +19,8 @@ class MyPlayListCVC: UICollectionViewCell {
     @IBOutlet weak var albumCountLabel: UILabel!
     
     func setData(data: MyPlayListData) {
-        albumImageView.image = UIImage(named: "cover_\(self.tag + 1)")!
+        albumImageView.image = self.tag < 10 ?
+        UIImage(named: "cover_\(self.tag + 1)")! : UIImage(named: "cover_\(self.tag - 10 + 1)")!
         albumTitleLabel.text = data.title
         albumCountLabel.text = data.description
     }


### PR DESCRIPTION
## PR 요약
내 음악 뷰에서 앱 크래시가 나는 이슈를 해결했습니다. (closed: #30)

## 작업 내용
```swift
func setData(data: MyPlayListData) {
    albumImageView.image = self.tag < 10 ?
    UIImage(named: "cover_\(self.tag + 1)")! : UIImage(named: "cover_\(self.tag - 10 + 1)")!
    albumTitleLabel.text = data.title
    albumCountLabel.text = data.description
}
```
삼항 연산자를 이용해서
10이 넘어가는 경우 다시 1번부터 이미지에 접근할 수 있도록 해주었습니다.