### PR TITLE
Fix: MyPlayListCVC Image Name 오류 해결

### DIFF
--- a/Client-iOS/Client-iOS/Scenes/MyMusic/Views/Cells/MyPlayListCVC.swift
+++ b/Client-iOS/Client-iOS/Scenes/MyMusic/Views/Cells/MyPlayListCVC.swift
@@ -19,8 +19,7 @@ class MyPlayListCVC: UICollectionViewCell {
     @IBOutlet weak var albumCountLabel: UILabel!
     
     func setData(data: MyPlayListData) {
-        albumImageView.image = self.tag < 10 ?
-        UIImage(named: "cover_\(self.tag + 1)")! : UIImage(named: "cover_\(self.tag - 10 + 1)")!
+        albumImageView.image = UIImage(named: "cover_\((self.tag % 10) + 1)")!
         albumTitleLabel.text = data.title
         albumCountLabel.text = data.description
     }


### PR DESCRIPTION
## 수정 사항
* MyPlayListCVC의 UIImage name을 세팅하는 과정에서, tag >= 20일 때부터 나타나는 오류를 해결하였습니다.